### PR TITLE
Fix task specification in helm.md

### DIFF
--- a/helm.md
+++ b/helm.md
@@ -16,7 +16,7 @@ You can configure which datasets to run HELM on by editing a `run_specs.conf`, t
 Here's how you can create a simple one for the purposes of making sure that your Dockerfile works
 
 ```bash
-echo 'entries: [  {description: "mmlu:model=text,subject=college_computer_science,data_augmentation=canonical", priority: 4}]' > run_specs.conf
+echo 'entries: [{description: "mmlu:model=neurips/local,subject=college_computer_science", priority: 4}]' > run_specs.conf
 helm-run --conf-paths run_specs.conf --suite v1 --max-eval-instances 1000
 helm-summarize --suite v1
 ```


### PR DESCRIPTION
Update the specification to instruct HELM to use the local model. Also, temporarily removing the `data_augmentation=canonical` setting which creates problems and would need a deeper look.