### PR TITLE
Examples/llama recipes

### DIFF
--- a/examples/llama_recipes/Dockerfile.inference
+++ b/examples/llama_recipes/Dockerfile.inference
@@ -9,15 +9,17 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install -U --no-cache-dir git+https://github.com/facebookresearch/llama-recipes.git@c33ea3cacb607a8b3cf9090b756504f869db8b9c
 
 WORKDIR /workspace
-RUN wget https://raw.githubusercontent.com/facebookresearch/llama-recipes/main/examples/custom_dataset.py
+# Setup server requriements
+COPY ./fast_api_requirements.txt fast_api_requirements.txt
+RUN pip install --no-cache-dir --upgrade -r fast_api_requirements.txt
+
+COPY ./output_dir output_dir
 
 ENV HF_DATASETS_CACHE="/volume/hf_cache"
 ENV TRANSFORMERS_CACHE="/volume/hf_cache"
 
-COPY run_training.sh /workspace/
-RUN chmod +x /workspace/run_training.sh
-
-WORKDIR /workspace
-
-CMD [ "/bin/bash", "-e", "/workspace/run_training.sh"]
-
+# Copy over single file server
+COPY ./main.py main.py
+COPY ./api.py api.py
+# Run the server
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/examples/llama_recipes/Dockerfile.inference
+++ b/examples/llama_recipes/Dockerfile.inference
@@ -1,4 +1,4 @@
-FROM ghcr.io/pytorch/pytorch-nightly:c69b6e5-cu11.8.0
+FROM ghcr.io/pytorch/pytorch-nightly:b3874ab-cu11.8.0
 
 RUN apt-get update  && apt-get install -y git python3-virtualenv wget 
 

--- a/examples/llama_recipes/Dockerfile.train
+++ b/examples/llama_recipes/Dockerfile.train
@@ -1,0 +1,32 @@
+FROM ghcr.io/pytorch/pytorch-nightly:c69b6e5-cu11.8.0
+
+RUN apt-get update  && apt-get install -y git
+
+RUN apt-get update  && apt-get install -y python3-virtualenv
+
+ENV VIRTUAL_ENV=/opt/venv
+
+RUN python -m venv $VIRTUAL_ENV
+
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip install -U --no-cache-dir git+https://github.com/facebookresearch/llama-recipes.git
+
+
+RUN apt-get update  && apt-get install -y wget
+
+WORKDIR /app
+
+RUN wget https://raw.githubusercontent.com/facebookresearch/llama-recipes/feature/oasst1_dataset/examples/custom_dataset.py
+
+ENV HF_DATASETS_CACHE="/workspace/hf_cache"
+ENV TRANSFORMERS_CACHE="/workspace/hf_cache"
+
+COPY run_training.sh /app/
+
+RUN chmod +x /app/run_training.sh
+
+WORKDIR /workspace
+
+CMD [ "/bin/bash", "-e", "/app/run_training.sh"]
+

--- a/examples/llama_recipes/Dockerfile.train
+++ b/examples/llama_recipes/Dockerfile.train
@@ -14,10 +14,7 @@ RUN wget https://raw.githubusercontent.com/facebookresearch/llama-recipes/main/e
 ENV HF_DATASETS_CACHE="/volume/hf_cache"
 ENV TRANSFORMERS_CACHE="/volume/hf_cache"
 
-COPY run_training.sh /workspace/
-RUN chmod +x /workspace/run_training.sh
-
 WORKDIR /workspace
 
-CMD [ "/bin/bash", "-e", "/workspace/run_training.sh"]
+CMD [ "/bin/bash", "-e", "-c","huggingface-cli login --token $HUGGINGFACE_TOKEN && python3 -m llama_recipes.finetuning  --model_name meta-llama/Llama-2-7b --use_peft --peft_method lora --quantization --batch_size_training 2 --dataset custom_dataset --custom_dataset.file /workspace/custom_dataset.py --output_dir /volume/output_dir"]
 

--- a/examples/llama_recipes/Dockerfile.train
+++ b/examples/llama_recipes/Dockerfile.train
@@ -1,4 +1,4 @@
-FROM ghcr.io/pytorch/pytorch-nightly:c69b6e5-cu11.8.0
+FROM ghcr.io/pytorch/pytorch-nightly:b3874ab-cu11.8.0
 
 RUN apt-get update  && apt-get install -y git python3-virtualenv wget 
 

--- a/examples/llama_recipes/README.md
+++ b/examples/llama_recipes/README.md
@@ -26,6 +26,8 @@ We can then train on this dataset using this command line:
 python3 -m llama_recipes.finetuning  --use_peft --peft_method lora --quantization --model_name meta-llama/Llama-2-7b --dataset custom_dataset --custom_dataset.file /workspace/custom_dataset.py --output_dir /volume/output_dir
 ```
 
+**Note** The custom dataset in this example is dialog based. This is only due to the nature of the example but not a necessity of the custom dataset functionality. To see other examples of get_custom_dataset functions (btw the name of the function get_custom_dataset can be changed in the command line by using this syntax: /workspace/custom_dataset.py:get_foo_dataset) have a look at the [built-in dataset in llama-recipes](https://github.com/facebookresearch/llama-recipes/blob/main/src/llama_recipes/datasets/__init__.py).
+
 # Create submission
 The creation of a submission will be split in two Dockerfiles. The training Docker will perform a fine tuning with the LoRA method and load the base Llama weight before training. The resulting LoRA weights are then saved on a volume that mounts a folder from the host file system. The inference Docker will copy the LoRA weights into the Docker to create a self-sufficient Docker which only depends on the access token to download the Llama 2 base weights from the HuggingFace hub.
 

--- a/examples/llama_recipes/README.md
+++ b/examples/llama_recipes/README.md
@@ -1,0 +1,30 @@
+# Llama-recipes example
+This example demonstrates how to fine-tune and serve a Llama v2 model with llama-recipes for submission in the LLM efficiency challenge using the [toy-submission](../../toy-submission/) as a template.
+Llama-recipes provides an easy way to fine-tune a Llama v2 with custom datasets using efficient techniques like LoRA or Llama-adapters.
+
+# Getting started
+In order to use llama-recipes we need to install the following pip package:
+```
+pip install llama-recipes
+```
+
+In order to obtain access to the model weights you need to fill out this [form](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) to accept the license terms and acceptable use policy.
+
+After access has been granted, you need to acknowledge this in your HuggingFace account for the model you want to fine-tune. In thsi example we will continue with the 7B parameter version available under this identifier: meta-llama/Llama-2-7b-hf
+
+# Fine-tune the model
+Fine-tuning the model on one of the preconfigured datasets can than be done with a single line command line:
+```
+python -m llama_recipes.finetuning  --use_peft --peft_method lora --quantization --model_name meta-llama/Llama-2-7b-hf --output_dir peft_model_output
+```
+
+
+
+
+# Create submission
+
+
+docker build -f ./Dockerfile.train -t train .
+
+export HUGGINGFACE_TOKEN="YOUR_HUGGINGFACE_TOKEN"
+docker run --gpus all --rm -ti -v ./:/workspace -e HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN  docker.io/library/train

--- a/examples/llama_recipes/README.md
+++ b/examples/llama_recipes/README.md
@@ -20,13 +20,8 @@ export  HUGGINGFACE_TOKEN="YOUR_HUGGINGFACE_TOKEN"
 Make sure that the token allows read access to meta-llama/Llama-2-7b-hf.
 
 # Fine-tune the model
-Fine-tuning the model on one of the preconfigured datasets can than be done with a single line command line:
-```bash
-python -m llama_recipes.finetuning  --use_peft --peft_method lora --quantization --model_name meta-llama/Llama-2-7b-hf --output_dir peft_model_output
-```
-
-To use load a custom dataset we need to implement a function (get_custom_datset) following [this](https://github.com/facebookresearch/llama-recipes/blob/main/examples/custom_dataset.py) example.
-We can than train on this dataset using this command line:
+With llama-recipes its possible to fine-tune Llama on custom data with a single command. To fine-tune on a custom dataset we need to implement a function (get_custom_dataset) that provides the custom dataset following this example [custom_dataset.py](https://github.com/facebookresearch/llama-recipes/blob/main/examples/custom_dataset.py).
+We can then train on this dataset using this command line:
 ```bash
 python3 -m llama_recipes.finetuning  --use_peft --peft_method lora --quantization --model_name meta-llama/Llama-2-7b --dataset custom_dataset --custom_dataset.file /workspace/custom_dataset.py --output_dir /volume/output_dir
 ```

--- a/examples/llama_recipes/README.md
+++ b/examples/llama_recipes/README.md
@@ -34,14 +34,14 @@ To build and run the taining Docker we need to execute:
 docker build -f ./Dockerfile.train -t llama_recipes_train .
 
 export HUGGINGFACE_TOKEN="YOUR_HUGGINGFACE_TOKEN"
-docker run --gpus all --rm -ti -v ./:/volume -e HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN  llama_recipes_train
+docker run --gpus "device=0" --rm -ti -v ./:/volume -e HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN  llama_recipes_train
 ```
 
 The inferenc Docker is created and started with:
 ```bash
 docker build -f ./Dockerfile.inference -t llama_recipes_inference .
 
-docker run --gpus all -p 8080:80 --volume ./:/volume -e HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN llama_recipes_inference
+docker run --gpus "device=0" -p 8080:80 --volume ./:/volume -e HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN llama_recipes_inference
 ```
 
 To test the inference docker we can run this query:

--- a/examples/llama_recipes/README.md
+++ b/examples/llama_recipes/README.md
@@ -1,6 +1,6 @@
 # Llama-recipes example
-This example demonstrates how to fine-tune and serve a Llama v2 model with llama-recipes for submission in the LLM efficiency challenge using the [toy-submission](../../toy-submission/) as a template.
-Llama-recipes provides an easy way to fine-tune a Llama v2 with custom datasets using efficient techniques like LoRA or Llama-adapters.
+This example demonstrates how to fine-tune and serve a Llama 2 model with llama-recipes for submission in the LLM efficiency challenge using the [toy-submission](../../toy-submission/) as a template.
+Llama-recipes provides an easy way to fine-tune a Llama 2 model with custom datasets using efficient techniques like LoRA or Llama-adapters.
 
 # Getting started
 In order to use llama-recipes we need to install the following pip package:
@@ -8,23 +8,48 @@ In order to use llama-recipes we need to install the following pip package:
 pip install llama-recipes
 ```
 
-In order to obtain access to the model weights you need to fill out this [form](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) to accept the license terms and acceptable use policy.
+To obtain access to the model weights you need to fill out this [form](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) to accept the license terms and acceptable use policy.
 
-After access has been granted, you need to acknowledge this in your HuggingFace account for the model you want to fine-tune. In thsi example we will continue with the 7B parameter version available under this identifier: meta-llama/Llama-2-7b-hf
+After access has been granted, you need to acknowledge this in your HuggingFace account for the model you want to fine-tune. In this example we will continue with the 7B parameter version available under this identifier: meta-llama/Llama-2-7b-hf
+In this example the authentication will be done through a token created in the settings of your HuggingFace account.
+When running the Docker, the token will be expected in an environment variable that can be created with:
+
+```bash
+export  HUGGINGFACE_TOKEN="YOUR_HUGGINGFACE_TOKEN"
+```
+Make sure that the token allows read access to meta-llama/Llama-2-7b-hf.
 
 # Fine-tune the model
 Fine-tuning the model on one of the preconfigured datasets can than be done with a single line command line:
-```
+```bash
 python -m llama_recipes.finetuning  --use_peft --peft_method lora --quantization --model_name meta-llama/Llama-2-7b-hf --output_dir peft_model_output
 ```
 
-
-
+To use load a custom dataset we need to implement a function (get_custom_datset) following [this](https://github.com/facebookresearch/llama-recipes/blob/main/examples/custom_dataset.py) example.
+We can than train on this dataset using this command line:
+```bash
+python3 -m llama_recipes.finetuning  --use_peft --peft_method lora --quantization --model_name meta-llama/Llama-2-7b --dataset custom_dataset --custom_dataset.file /workspace/custom_dataset.py --output_dir /volume/output_dir
+```
 
 # Create submission
+The creation of a submission will be split in two Dockerfiles. The training Docker will perform a fine tuning with the LoRA method and load the base Llama weight before training. The resulting LoRA weights are then saved on a volume that mounts a folder from the host file system. The inference Docker will copy the LoRA weights into the Docker to create a self-sufficient Docker which only depends on the access token to download the Llama 2 base weights from the HuggingFace hub.
 
-
-docker build -f ./Dockerfile.train -t train .
+To build and run the taining Docker we need to execute:
+```bash
+docker build -f ./Dockerfile.train -t llama_recipes_train .
 
 export HUGGINGFACE_TOKEN="YOUR_HUGGINGFACE_TOKEN"
-docker run --gpus all --rm -ti -v ./:/workspace -e HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN  docker.io/library/train
+docker run --gpus all --rm -ti -v ./:/volume -e HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN  llama_recipes_train
+```
+
+The inferenc Docker is created and started with:
+```bash
+docker build -f ./Dockerfile.inference -t llama_recipes_inference .
+
+docker run --gpus all -p 8080:80 --volume ./:/volume -e HUGGINGFACE_TOKEN=$HUGGINGFACE_TOKEN llama_recipes_inference
+```
+
+To test the inference docker we can run this query:
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"text": "[INST]Was is the capital of france?[/INST] "}' http://localhost:8080/tokenize
+```

--- a/examples/llama_recipes/api.py
+++ b/examples/llama_recipes/api.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel
+
+from typing import List, Dict, Optional
+
+
+class ProcessRequest(BaseModel):
+    prompt: str
+    num_samples: int = 1
+    max_new_tokens: int = 50
+    top_k: int = 200
+    temperature: float = 0.8
+    seed: Optional[int] = None
+
+
+class Token(BaseModel):
+    text: str
+    logprob: float
+    top_logprob: Dict[str, float]
+
+
+class ProcessResponse(BaseModel):
+    text: str
+    tokens: List[Token]
+    logprob: float
+    request_time: float
+
+
+class TokenizeRequest(BaseModel):
+    text: str
+    truncation: bool = True
+    max_length: int = 2048
+
+
+class TokenizeResponse(BaseModel):
+    tokens: List[int]
+    request_time: float

--- a/examples/llama_recipes/fast_api_requirements.txt
+++ b/examples/llama_recipes/fast_api_requirements.txt
@@ -1,0 +1,4 @@
+# FAST API
+fastapi>=0.68.0,<0.69.0
+pydantic>=1.8.0,<2.0.0
+uvicorn>=0.15.0,<0.16.0

--- a/examples/llama_recipes/main.py
+++ b/examples/llama_recipes/main.py
@@ -1,0 +1,110 @@
+from fastapi import FastAPI
+
+import logging
+import os
+import time
+
+import torch
+from huggingface_hub import login
+from transformers import LlamaTokenizer
+from llama_recipes.inference.model_utils import load_model, load_peft_model
+
+torch.set_float32_matmul_precision("high")
+
+from api import (
+    ProcessRequest,
+    ProcessResponse,
+    TokenizeRequest,
+    TokenizeResponse,
+    Token,
+)
+
+app = FastAPI()
+
+logger = logging.getLogger(__name__)
+# Configure the logging module
+logging.basicConfig(level=logging.INFO)
+
+login(token=os.environ["HUGGINGFACE_TOKEN"])
+
+model = load_model('meta-llama/Llama-2-7b', True)
+model = load_peft_model(model, '/workspace/output_dir')
+
+model.eval()
+
+tokenizer = LlamaTokenizer.from_pretrained('meta-llama/Llama-2-7b')
+
+LLAMA2_CONTEXT_LENGTH = 4096
+
+
+@app.post("/process")
+async def process_request(input_data: ProcessRequest) -> ProcessResponse:
+    if input_data.seed is not None:
+        torch.manual_seed(input_data.seed)
+    
+    encoded = tokenizer(input_data.prompt, return_tensors="pt")
+    
+    prompt_length = encoded["input_ids"][0].size(0)
+    max_returned_tokens = prompt_length + input_data.max_new_tokens
+    assert max_returned_tokens <= LLAMA2_CONTEXT_LENGTH, (
+        max_returned_tokens,
+        LLAMA2_CONTEXT_LENGTH,
+    )
+
+    t0 = time.perf_counter()
+    encoded = {k: v.to("cuda") for k, v in encoded.items()}
+    with torch.no_grad():
+        outputs = model.generate(
+            **encoded,
+            max_new_tokens=input_data.max_new_tokens,
+            do_sample=True,
+            temperature=input_data.temperature,
+            top_k=input_data.top_k,
+            return_dict_in_generate=True,
+            output_scores=True,
+        )
+    
+    t = time.perf_counter() - t0
+
+    output = tokenizer.decode(outputs.sequences[0], skip_special_tokens=True)
+    tokens_generated = outputs.sequences[0].size(0) - prompt_length
+    logger.info(
+        f"Time for inference: {t:.02f} sec total, {tokens_generated / t:.02f} tokens/sec"
+    )
+
+    logger.info(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB")
+    generated_tokens = []
+    
+    log_probs = torch.log(torch.stack(outputs.scores, dim=1).softmax(-1))
+
+    gen_sequences = outputs.sequences[:, encoded["input_ids"].shape[-1]:]
+    gen_logprobs = torch.gather(log_probs, 2, gen_sequences[:, :, None]).squeeze(-1)
+
+    top_indices = torch.argmax(log_probs, dim=-1)
+    top_logprobs = torch.gather(log_probs, 2, top_indices[:,:,None]).squeeze(-1)
+    top_indices = top_indices.tolist()[0]
+    top_logprobs = top_logprobs.tolist()[0]
+
+    for t, lp, tlp in zip(gen_sequences.tolist()[0], gen_logprobs.tolist()[0], zip(top_indices, top_logprobs)):
+        idx, val = tlp
+        tok_str = tokenizer.decode(idx)
+        token_tlp = {tok_str: val}
+        generated_tokens.append(
+            Token(text=tokenizer.decode(t), logprob=lp, top_logprob=token_tlp)
+        )
+    logprob_sum = gen_logprobs.sum().item()
+    
+    return ProcessResponse(
+        text=output, tokens=generated_tokens, logprob=logprob_sum, request_time=t
+    )
+
+
+@app.post("/tokenize")
+async def tokenize(input_data: TokenizeRequest) -> TokenizeResponse:
+    t0 = time.perf_counter()
+    encoded = tokenizer(
+        input_data.text
+    )
+    t = time.perf_counter() - t0
+    tokens = encoded["input_ids"]
+    return TokenizeResponse(tokens=tokens, request_time=t)

--- a/examples/llama_recipes/run_training.sh
+++ b/examples/llama_recipes/run_training.sh
@@ -2,4 +2,4 @@
 
 huggingface-cli login --token $HUGGINGFACE_TOKEN
 
-python3 -m llama_recipes.finetuning  --model_name decapoda-research/llama-7b-hf --use_peft --peft_method lora --quantization --batch_size_training 2 --dataset custom_dataset --custom_dataset.file /app/custom_dataset.py --output_dir /volume/output_dir
+python3 -m llama_recipes.finetuning  --model_name meta-llama/Llama-2-7b --use_peft --peft_method lora --quantization --batch_size_training 2 --dataset custom_dataset --custom_dataset.file /workspace/custom_dataset.py --output_dir /volume/output_dir

--- a/examples/llama_recipes/run_training.sh
+++ b/examples/llama_recipes/run_training.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+huggingface-cli login --token $HUGGINGFACE_TOKEN
+
+python3 -m llama_recipes.finetuning  --model_name decapoda-research/llama-7b-hf --use_peft --peft_method lora --quantization --batch_size_training 2 --dataset custom_dataset --custom_dataset.file /app/custom_dataset.py --output_dir /volume/output_dir

--- a/examples/llama_recipes/run_training.sh
+++ b/examples/llama_recipes/run_training.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-huggingface-cli login --token $HUGGINGFACE_TOKEN
-
-python3 -m llama_recipes.finetuning  --model_name meta-llama/Llama-2-7b --use_peft --peft_method lora --quantization --batch_size_training 2 --dataset custom_dataset --custom_dataset.file /workspace/custom_dataset.py --output_dir /volume/output_dir


### PR DESCRIPTION
This PR adds an end to end example to fine-tune a Llama 2 model using llama-recipes using LoRA and int8 quantization.

The README.md shows how to create the training and inference Docker. Llama 2 base models weights are obtained through the huggingface hub while the LoRA weights are copied into the Docker.