### PR TITLE
fix lit-gpt Docker, helper.py and main.py

### DIFF
--- a/sample-submissions/lit-gpt/Dockerfile
+++ b/sample-submissions/lit-gpt/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /submission
 
 # Copy the specific file into the container at /submission
 COPY /lit-gpt/ /submission/
+RUN mkdir checkpoints
+RUN mkdir checkpoints/openlm-research
+RUN mkdir checkpoints/openlm-research/open_llama_3b
 
 # Setup server requriements
 COPY ./fast_api_requirements.txt fast_api_requirements.txt

--- a/sample-submissions/lit-gpt/helper.py
+++ b/sample-submissions/lit-gpt/helper.py
@@ -48,7 +48,7 @@ def toysubmission_generate(
         x = idx.index_select(0, input_pos).view(1, -1)
 
         # forward
-        logits = model(x, max_seq_length, input_pos)
+        logits = model(x, input_pos)
         logits = logits[0, -1] / temperature
 
         # optionally crop the logits to only the top k options

--- a/sample-submissions/lit-gpt/main.py
+++ b/sample-submissions/lit-gpt/main.py
@@ -88,7 +88,6 @@ async def process_request(input_data: ProcessRequest) -> ProcessResponse:
 
     t = time.perf_counter() - t0
 
-    model.reset_cache()
     if input_data.echo_prompt is False:
         output = tokenizer.decode(tokens[prompt_length:])
     else:


### PR DESCRIPTION
Changes:
1. change in `sample-submissions/lit-gpt/helper.py` `logits = model(x, max_seq_length, input_pos)` to `logits = model(x, input_pos)`
2. remove [this line](https://github.com/llm-efficiency-challenge/neurips_llm_efficiency_challenge/blob/bbf2f8013551ee858b03feb8e97d2ef1530e924d/sample-submissions/lit-gpt/main.py#L91C24-L91C24) 

Other changes within `lit-gpt` to make it work that is not included in this PR (because it's on `lit-gpt` side)
1. uncomment all the optional requirements in `requirements.txt`
1. add `self.set_kv_cache(batch_size=1, device="cuda:0", dtype=torch.bfloat16)` in line 82 here: https://github.com/Lightning-AI/lit-gpt/blob/main/lit_gpt/model.py#L82