### PR TITLE
Speedup model inference 

### DIFF
--- a/sample-submissions/llama_recipes/main.py
+++ b/sample-submissions/llama_recipes/main.py
@@ -6,8 +6,8 @@ import time
 
 import torch
 from huggingface_hub import login
-from transformers import LlamaTokenizer
-from llama_recipes.inference.model_utils import load_model, load_peft_model
+from transformers import LlamaTokenizer, LlamaForCausalLM
+from llama_recipes.inference.model_utils import load_peft_model
 
 torch.set_float32_matmul_precision("high")
 
@@ -27,7 +27,12 @@ logging.basicConfig(level=logging.INFO)
 
 login(token=os.environ["HUGGINGFACE_TOKEN"])
 
-model = load_model('meta-llama/Llama-2-7b-hf', True)
+model = LlamaForCausalLM.from_pretrained(
+    'meta-llama/Llama-2-7b-hf',
+    return_dict=True,
+    torch_dtype=torch.float16,
+    device_map="cuda"
+    )
 model = load_peft_model(model, os.environ["HUGGINGFACE_REPO"])
 
 model.eval()

--- a/sample-submissions/llama_recipes/train.py
+++ b/sample-submissions/llama_recipes/train.py
@@ -14,7 +14,7 @@ def main():
         "batch_size_training": 2,
         "dataset": "custom_dataset",
         "custom_dataset.file": "./custom_dataset.py",
-        "output_dir": "./output_dir ",
+        "output_dir": "./output_dir",
     }
     
     finetuning(**kwargs)


### PR DESCRIPTION
The llama-recipes example uses bitsandbytes quantization during inference which is slow
due to https://github.com/TimDettmers/bitsandbytes/issues/6

This PR replaces this with just loading it in fp16 instead which results in 2x the performance